### PR TITLE
[github #13] Avro/json deserialization error handling for kafka readers

### DIFF
--- a/consumers-spark/src/test/scala/it/agilelab/bigdata/wasp/consumers/spark/http/etl/package.scala
+++ b/consumers-spark/src/test/scala/it/agilelab/bigdata/wasp/consumers/spark/http/etl/package.scala
@@ -5,7 +5,7 @@ import it.agilelab.bigdata.wasp.models.{StrategyModel, StreamingReaderModel, Str
 package object etl {
   lazy val sampleStreamingETL = StructuredStreamingETLModel(
     name = "sample-data-to-console",
-    streamingInput = StreamingReaderModel.kafkaReader("read-from-kafka", topic.fromKafkaInputTopic, None),
+    streamingInput = StreamingReaderModel.kafkaReader("read-from-kafka", topic.fromKafkaInputTopic, None, Map.empty),
     staticInputs = List.empty,
     streamingOutput = WriterModel.kafkaWriter("write-to-kafka", topic.sampleDataOutputTopic),
     mlModels = List.empty,

--- a/consumers-spark/src/test/scala/it/agilelab/bigdata/wasp/consumers/spark/streaming/actor/pipegraph/PipegraphGuardianSpec.scala
+++ b/consumers-spark/src/test/scala/it/agilelab/bigdata/wasp/consumers/spark/streaming/actor/pipegraph/PipegraphGuardianSpec.scala
@@ -48,21 +48,17 @@ class PipegraphGuardianSpec
     isSystem = false,
     creationTime = System.currentTimeMillis(),
     structuredStreamingComponents = List(
-      StructuredStreamingETLModel(
-        name = "component",
-        streamingInput = StreamingReaderModel.kafkaReader("", DatastoreModelsForTesting.TopicModels.json, None),
-        staticInputs = List.empty,
-        streamingOutput = WriterModel.solrWriter("", DatastoreModelsForTesting.IndexModels.solr),
-        mlModels = List(),
-        strategy = None,
-        triggerIntervalMs = None,
-        options = Map()
-      )
-    ),
-    dashboard = None
-  )
-  val defaultInstance = PipegraphInstanceModel(
-    name = "pipegraph-1",
+      StructuredStreamingETLModel(name = "component",
+                                  streamingInput = StreamingReaderModel.kafkaReader("", DatastoreModelsForTesting.TopicModels.json, None),
+                                  staticInputs = List.empty,
+                                  streamingOutput = WriterModel.solrWriter("", DatastoreModelsForTesting.IndexModels.solr),
+                                  mlModels = List(),
+                                  strategy = None,
+                                  triggerIntervalMs = None,
+                                  options = Map()
+      )),
+    dashboard = None)
+  val defaultInstance = PipegraphInstanceModel(name = "pipegraph-1",
     instanceOf = "pipegraph",
     startTimestamp = 1L,
     currentStatusTimestamp = 0L,

--- a/core/src/main/scala/it/agilelab/bigdata/wasp/core/eventengine/EventTopicModelFactory.scala
+++ b/core/src/main/scala/it/agilelab/bigdata/wasp/core/eventengine/EventTopicModelFactory.scala
@@ -45,8 +45,9 @@ object EventReaderModelFactory {
     val name = modelSettings.modelName
     val dataStoreName = TopicModel.name(modelSettings.dataStoreModelName)
     val options = modelSettings.options
+    val parsingMode = modelSettings.parsingMode
     val rateLimit: Option[Int] = options.get("rate-limit").flatMap(s => Some(s.toInt))
 
-    new StreamingReaderModel(name, dataStoreName, KafkaProduct, rateLimit, options)
+    new StreamingReaderModel(name, dataStoreName, KafkaProduct, rateLimit, options, parsingMode)
   }
 }

--- a/core/src/main/scala/it/agilelab/bigdata/wasp/core/eventengine/settings/EventEngineSettings.scala
+++ b/core/src/main/scala/it/agilelab/bigdata/wasp/core/eventengine/settings/EventEngineSettings.scala
@@ -3,6 +3,7 @@ package it.agilelab.bigdata.wasp.core.eventengine.settings
 import com.typesafe.config.Config
 import it.agilelab.bigdata.wasp.core.eventengine.eventconsumers.MailingRule
 import it.agilelab.bigdata.wasp.core.eventengine.eventproducers.EventRule
+import it.agilelab.bigdata.wasp.models.configuration.{ParsingMode, Strict}
 
 /**
   * Models supported by the event engine to load and store events
@@ -61,7 +62,8 @@ case class EventConsumerETLSettings(name: String,
 case class ModelSettings(modelName: String,
                          dataStoreModelName: String,
                          modelType: ModelTypes.Value,
-                         options: Map[String, String] = Map.empty)
+                         options: Map[String, String] = Map.empty,
+                         parsingMode: ParsingMode = Strict)
 
 /**
   * Defines settings for a single EventStrategy

--- a/model/src/main/scala/it/agilelab/bigdata/wasp/models/ReaderModel.scala
+++ b/model/src/main/scala/it/agilelab/bigdata/wasp/models/ReaderModel.scala
@@ -1,6 +1,7 @@
 package it.agilelab.bigdata.wasp.models
 
 import it.agilelab.bigdata.wasp.datastores._
+import it.agilelab.bigdata.wasp.models.configuration.{ParsingMode, Strict}
 
 /**
 	* A model for a reader, composed by a name, a datastoreModelName defining the datastore, a datastoreProduct
@@ -11,11 +12,13 @@ import it.agilelab.bigdata.wasp.datastores._
 	* @param datastoreProduct the datastore software product to be used when reading
   * @param options additional options for the reader
 	*/
+
 case class ReaderModel private[wasp](
     name: String,
     datastoreModelName: String,
     datastoreProduct: DatastoreProduct,
-    options: Map[String, String]
+    options: Map[String, String],
+    parsingMode: ParsingMode
 )
 
 object ReaderModel {
@@ -25,33 +28,35 @@ object ReaderModel {
       name: String,
       datastoreModel: DatastoreModel,
       datastoreProduct: DatastoreProduct,
-      options: Map[String, String] = Map.empty
+      options: Map[String, String] = Map.empty,
+      parsingMode: ParsingMode = Strict
   ): ReaderModel = {
-    ReaderModel(name, datastoreModel, datastoreProduct, options)
+    ReaderModel(name, datastoreModel, datastoreProduct, options, parsingMode)
   }
 
-  def jdbcReader(name: String, sqlSourceModel: SqlSourceModel, options: Map[String, String] = Map.empty) =
-    apply(name, sqlSourceModel.name, JDBCProduct, options)
-  def indexReader(name: String, indexModel: IndexModel, options: Map[String, String] = Map.empty) =
-    apply(name, indexModel.name, GenericIndexProduct, options)
-  def elasticReader(name: String, indexModel: IndexModel, options: Map[String, String] = Map.empty) =
-    apply(name, indexModel.name, ElasticProduct, options)
-  def solrReader(name: String, indexModel: IndexModel, options: Map[String, String] = Map.empty) =
-    apply(name, indexModel.name, SolrProduct, options)
-  def keyValueReader(name: String, keyValueModel: KeyValueModel, options: Map[String, String] = Map.empty) =
-    apply(name, keyValueModel.name, GenericKeyValueProduct, options)
-  def hbaseReader(name: String, keyValueModel: KeyValueModel, options: Map[String, String] = Map.empty) =
-    apply(name, keyValueModel.name, HBaseProduct, options)
-  def topicReader(name: String, topicModel: TopicModel, options: Map[String, String] = Map.empty) =
-    apply(name, topicModel.name, GenericTopicProduct, options)
-  def kafkaReader(name: String, topicModel: TopicModel, options: Map[String, String] = Map.empty) =
-    apply(name, topicModel.name, KafkaProduct, options)
-  def kafkaReaderMultitopic(name: String, multiTopicModel: MultiTopicModel, options: Map[String, String] = Map.empty) =
-    apply(name, multiTopicModel.name, KafkaProduct, options)
-  def rawReader(name: String, rawModel: RawModel, options: Map[String, String] = Map.empty) =
-    apply(name, rawModel.name, RawProduct, options)
-  def websocketReader(name: String, websocketModel: WebsocketModel, options: Map[String, String] = Map.empty) =
-    apply(name, websocketModel.name, WebSocketProduct, options)
-  def mongoDbReader(name: String, documentModel: DocumentModel, options: Map[String, String]): ReaderModel =
-    apply(name, documentModel.name, MongoDbProduct, options)
+	def jdbcReader(name: String, sqlSourceModel: SqlSourceModel, options: Map[String, String] = Map.empty, parsingMode: ParsingMode = Strict) =
+		apply(name, sqlSourceModel, JDBCProduct, options, parsingMode)
+	def indexReader(name: String, indexModel: IndexModel, options: Map[String, String] = Map.empty, parsingMode: ParsingMode = Strict) =
+    apply(name, indexModel, GenericIndexProduct, options, parsingMode)
+	def elasticReader(name: String, indexModel: IndexModel, options: Map[String, String] = Map.empty, parsingMode: ParsingMode = Strict) =
+    apply(name, indexModel, ElasticProduct, options, parsingMode)
+	def solrReader(name: String, indexModel: IndexModel, options: Map[String, String] = Map.empty, parsingMode: ParsingMode = Strict) =
+    apply(name, indexModel, SolrProduct, options, parsingMode)
+	def keyValueReader(name: String, keyValueModel: KeyValueModel, options: Map[String, String] = Map.empty, parsingMode: ParsingMode = Strict) =
+    apply(name, keyValueModel, GenericKeyValueProduct, options, parsingMode)
+	def hbaseReader(name: String, keyValueModel: KeyValueModel, options: Map[String, String] = Map.empty, parsingMode: ParsingMode = Strict) =
+    apply(name, keyValueModel, HBaseProduct, options, parsingMode)
+	def topicReader(name: String, topicModel: TopicModel, options: Map[String, String] = Map.empty, parsingMode: ParsingMode = Strict) =
+    apply(name, topicModel, GenericTopicProduct, options, parsingMode)
+	def kafkaReader(name: String, topicModel: TopicModel, options: Map[String, String] = Map.empty, parsingMode: ParsingMode = Strict) =
+    apply(name, topicModel, KafkaProduct, options, parsingMode)
+	def kafkaReaderMultitopic(name: String, multiTopicModel: MultiTopicModel, options: Map[String, String] = Map.empty, parsingMode: ParsingMode = Strict) =
+		apply(name, multiTopicModel, KafkaProduct, options, parsingMode)
+	def rawReader(name: String, rawModel: RawModel, options: Map[String, String] = Map.empty, parsingMode: ParsingMode = Strict) =
+    apply(name, rawModel, RawProduct, options, parsingMode)
+	def websocketReader(name: String, websocketModel: WebsocketModel, options: Map[String, String] = Map.empty, parsingMode: ParsingMode = Strict) =
+    apply(name, websocketModel, WebSocketProduct, options, parsingMode)
+	def mongoDbReader(name: String, documentModel: DocumentModel, options: Map[String, String], parsingMode: ParsingMode = Strict): ReaderModel =
+		apply(name, documentModel, MongoDbProduct, options, parsingMode)
+
 }

--- a/model/src/main/scala/it/agilelab/bigdata/wasp/models/StreamingReaderModel.scala
+++ b/model/src/main/scala/it/agilelab/bigdata/wasp/models/StreamingReaderModel.scala
@@ -1,5 +1,6 @@
 package it.agilelab.bigdata.wasp.models
 
+import it.agilelab.bigdata.wasp.models.configuration.{ParsingMode, Strict}
 import it.agilelab.bigdata.wasp.datastores.DatastoreProduct
 
 case class StreamingReaderModel private[wasp] (
@@ -7,7 +8,8 @@ case class StreamingReaderModel private[wasp] (
     datastoreModelName: String,
     datastoreProduct: DatastoreProduct,
     rateLimit: Option[Int],
-    options: Map[String, String]
+    options: Map[String, String],
+    parsingMode: ParsingMode
 )
 
 object StreamingReaderModel {
@@ -18,43 +20,50 @@ object StreamingReaderModel {
       datastoreModel: DatastoreModel,
       datastoreProduct: DatastoreProduct,
       rateLimit: Option[Int],
-      options: Map[String, String] = Map.empty
+      options: Map[String, String] = Map.empty,
+      parsingMode: ParsingMode = Strict
   ): StreamingReaderModel = {
-    StreamingReaderModel(name, datastoreModel.name, datastoreProduct, rateLimit, options)
+    StreamingReaderModel(name, datastoreModel.name, datastoreProduct, rateLimit, options, parsingMode)
   }
 
   def topicReader(
       name: String,
       topicModel: TopicModel,
       rateLimit: Option[Int],
-      options: Map[String, String] = Map.empty
+      options: Map[String, String] = Map.empty,
+      parsingMode: ParsingMode = Strict
+
   ): StreamingReaderModel =
-    apply(name, topicModel.name, GenericTopicProduct, rateLimit, options)
+    apply(name, topicModel.name, GenericTopicProduct, rateLimit, options, parsingMode)
 
   def kafkaReader(
       name: String,
       topicModel: TopicModel,
       rateLimit: Option[Int],
-      options: Map[String, String] = Map.empty
+      options: Map[String, String] = Map.empty,
+      parsingMode: ParsingMode = Strict
   ): StreamingReaderModel =
-    apply(name, topicModel.name, KafkaProduct, rateLimit, options)
+    apply(name, topicModel.name, KafkaProduct, rateLimit, options, parsingMode)
 
   def kafkaReaderMultitopic(
       name: String,
       multiTopicModel: MultiTopicModel,
       rateLimit: Option[Int],
-      options: Map[String, String] = Map.empty
+      options: Map[String, String] = Map.empty,
+      parsingMode: ParsingMode = Strict
   ): StreamingReaderModel =
-    apply(name, multiTopicModel.name, KafkaProduct, rateLimit, options)
+    apply(name, multiTopicModel.name, KafkaProduct, rateLimit, options, parsingMode)
 
-  def rawReader(name: String, rawModel: RawModel, options: Map[String, String] = Map.empty): StreamingReaderModel =
-    apply(name, rawModel.name, RawProduct, None, options)
+  def rawReader(name: String, rawModel: RawModel, options: Map[String, String] = Map.empty,
+                parsingMode: ParsingMode = Strict): StreamingReaderModel =
+    apply(name, rawModel.name, RawProduct, None, options, parsingMode)
 
   def websocketReader(
       name: String,
       websocketModel: WebsocketModel,
       rateLimit: Option[Int],
-      options: Map[String, String] = Map.empty
+      options: Map[String, String] = Map.empty,
+      parsingMode: ParsingMode = Strict
   ): StreamingReaderModel =
-    apply(name, websocketModel.name, WebSocketProduct, rateLimit, options)
+    apply(name, websocketModel.name, WebSocketProduct, rateLimit, options, parsingMode)
 }

--- a/model/src/main/scala/it/agilelab/bigdata/wasp/models/configuration/ParsingMode.scala
+++ b/model/src/main/scala/it/agilelab/bigdata/wasp/models/configuration/ParsingMode.scala
@@ -1,0 +1,17 @@
+package it.agilelab.bigdata.wasp.models.configuration
+
+sealed abstract class ParsingMode(val mode: String)
+
+case object Strict extends ParsingMode("strict")
+
+case object Ignore extends ParsingMode("ignore")
+
+case object Handle extends ParsingMode("handle")
+
+object ParsingMode {
+  val map = List(Strict, Ignore, Handle).map(x => (x.mode, x)).toMap
+
+  def asString(parsingMode: ParsingMode): String = parsingMode.mode
+
+  def fromString(parsingMode: String): Option[ParsingMode] = map.get(parsingMode)
+}

--- a/model/src/main/scala/it/agilelab/bigdata/wasp/utils/BsonConvertToSprayJson.scala
+++ b/model/src/main/scala/it/agilelab/bigdata/wasp/utils/BsonConvertToSprayJson.scala
@@ -9,6 +9,7 @@ import it.agilelab.bigdata.wasp.datastores.{DatastoreProduct, GenericProduct}
 import it.agilelab.bigdata.wasp.models.configuration._
 import it.agilelab.bigdata.wasp.models.editor._
 import it.agilelab.bigdata.wasp.models._
+import org.apache.spark.SparkException
 import org.json4s.{DefaultFormats, Formats, JObject}
 import org.mongodb.scala.bson.{BsonDocument, BsonObjectId}
 import spray.json.{JsValue, RootJsonFormat, deserializationError, _}
@@ -29,7 +30,7 @@ object BsonConvertToSprayJson extends SprayJsonSupport with DefaultJsonProtocol 
 
     def read(value: JsValue): BsonObjectId = value match {
       case JsString(objectId) => BsonObjectId(objectId)
-      case _ => deserializationError("String expected")
+      case _                  => deserializationError("String expected")
     }
   }
 
@@ -51,14 +52,14 @@ class EnumJsonConverter[T <: scala.Enumeration](enu: T) extends RootJsonFormat[T
 }
 
 class TypesafeConfigJsonConverter() extends RootJsonFormat[Config] {
-  val ParseOptions = ConfigParseOptions.defaults().setSyntax(ConfigSyntax.JSON)
+  val ParseOptions  = ConfigParseOptions.defaults().setSyntax(ConfigSyntax.JSON)
   val RenderOptions = ConfigRenderOptions.concise().setJson(true)
 
   override def write(config: Config): JsValue = JsonParser(config.root.render(RenderOptions))
 
   override def read(jsValue: JsValue): Config = jsValue match {
     case obj: JsObject => ConfigFactory.parseString(obj.compactPrint, ParseOptions)
-    case _ => deserializationError("Expected JsObject for Config deserialization")
+    case _             => deserializationError("Expected JsObject for Config deserialization")
   }
 }
 
@@ -68,7 +69,7 @@ class TypesafeConfigJsonConverter() extends RootJsonFormat[Config] {
   * @author Nicolò Bidotti
   */
 class TopicDatastoreModelJsonFormat
-  extends RootJsonFormat[DatastoreModel]
+    extends RootJsonFormat[DatastoreModel]
     with SprayJsonSupport
     with DefaultJsonProtocol {
 
@@ -81,7 +82,7 @@ class TopicDatastoreModelJsonFormat
     override def read(json: JsValue): TopicCompression =
       json match {
         case JsString(value) => TopicCompression.fromString(value)
-        case other => throw new RuntimeException(s"Cannot parse topic compression from $other")
+        case other           => throw new RuntimeException(s"Cannot parse topic compression from $other")
       }
   }
 
@@ -92,26 +93,25 @@ class TopicDatastoreModelJsonFormat
     override def read(json: JsValue): SubjectStrategy =
       json match {
         case JsString(value) => SubjectStrategy.fromString(value)
-        case other => throw new RuntimeException(s"Cannot parse subject strategy from $other")
+        case other           => throw new RuntimeException(s"Cannot parse subject strategy from $other")
       }
   }
 
-
-  implicit val topicModelFormat: RootJsonFormat[TopicModel] = jsonFormat13(TopicModel.apply)
+  implicit val topicModelFormat: RootJsonFormat[TopicModel]           = jsonFormat13(TopicModel.apply)
   implicit val multiTopicModelFormat: RootJsonFormat[MultiTopicModel] = jsonFormat3(MultiTopicModel.apply)
 
   override def write(obj: DatastoreModel): JsValue = {
     obj match {
-      case topicModel: TopicModel => topicModel.toJson
+      case topicModel: TopicModel           => topicModel.toJson
       case multiTopicModel: MultiTopicModel => multiTopicModel.toJson
     }
   }
 
   override def read(json: JsValue): DatastoreModel = {
-    val obj = json.asJsObject
+    val obj    = json.asJsObject
     val fields = obj.fields
     obj match {
-      case topicModel if fields.contains("partitions") => topicModel.convertTo[TopicModel]
+      case topicModel if fields.contains("partitions")          => topicModel.convertTo[TopicModel]
       case multiTopicModel if fields.contains("topicNameField") => multiTopicModel.convertTo[MultiTopicModel]
     }
   }
@@ -119,7 +119,7 @@ class TopicDatastoreModelJsonFormat
 
 // collect your json format instances into a support trait:
 trait JsonSupport
-  extends SprayJsonSupport
+    extends SprayJsonSupport
     with DefaultJsonProtocol
     with DataStoreConfJsonSupport
     with BatchJobJsonSupport {
@@ -137,28 +137,33 @@ trait JsonSupport
       case other => throw new RuntimeException(s"Cannot parse Instant from $other")
     }
   }
-  implicit lazy val batchSchedulerModelFormat: RootJsonFormat[BatchSchedulerModel] = jsonFormat5(BatchSchedulerModel.apply)
+  implicit lazy val batchSchedulerModelFormat: RootJsonFormat[BatchSchedulerModel] = jsonFormat5(
+    BatchSchedulerModel.apply
+  )
   implicit lazy val countEntryFormat: RootJsonFormat[CountEntry] = jsonFormat2(CountEntry.apply)
-  implicit lazy val countsFormat: RootJsonFormat[Counts] = jsonFormat3(Counts.apply)
+  implicit lazy val countsFormat: RootJsonFormat[Counts]         = jsonFormat3(Counts.apply)
 
-  implicit lazy val telemetryPointFormat: RootJsonFormat[TelemetryPoint] = jsonFormat2(TelemetryPoint.apply)
+  implicit lazy val telemetryPointFormat: RootJsonFormat[TelemetryPoint]   = jsonFormat2(TelemetryPoint.apply)
   implicit lazy val telemetrySeriesFormat: RootJsonFormat[TelemetrySeries] = jsonFormat3(TelemetrySeries.apply)
-  implicit lazy val metricEntryFormat: RootJsonFormat[MetricEntry] = jsonFormat2(MetricEntry.apply)
-  implicit lazy val metricsFormat: RootJsonFormat[Metrics] = jsonFormat2(Metrics.apply)
-  implicit lazy val logsFormat: RootJsonFormat[Logs] = jsonFormat2(Logs.apply)
-  implicit lazy val logEntryFormat: RootJsonFormat[LogEntry] = jsonFormat7(LogEntry.apply)
-  implicit lazy val sourceEntryFormat: RootJsonFormat[SourceEntry] = jsonFormat1(SourceEntry.apply)
-  implicit lazy val sourcesFormat: RootJsonFormat[Sources] = jsonFormat2(Sources.apply)
-  implicit lazy val eventsFormat: RootJsonFormat[Events] = jsonFormat2(Events.apply)
-  implicit lazy val eventEntryFormat: RootJsonFormat[EventEntry] = jsonFormat8(EventEntry.apply)
+  implicit lazy val metricEntryFormat: RootJsonFormat[MetricEntry]         = jsonFormat2(MetricEntry.apply)
+  implicit lazy val metricsFormat: RootJsonFormat[Metrics]                 = jsonFormat2(Metrics.apply)
+  implicit lazy val logsFormat: RootJsonFormat[Logs]                       = jsonFormat2(Logs.apply)
+  implicit lazy val logEntryFormat: RootJsonFormat[LogEntry]               = jsonFormat7(LogEntry.apply)
+  implicit lazy val sourceEntryFormat: RootJsonFormat[SourceEntry]         = jsonFormat1(SourceEntry.apply)
+  implicit lazy val sourcesFormat: RootJsonFormat[Sources]                 = jsonFormat2(Sources.apply)
+  implicit lazy val eventsFormat: RootJsonFormat[Events]                   = jsonFormat2(Events.apply)
+  implicit lazy val eventEntryFormat: RootJsonFormat[EventEntry]           = jsonFormat8(EventEntry.apply)
   implicit lazy val jmxTelemetryTopicConfigModel: RootJsonFormat[JMXTelemetryConfigModel] = jsonFormat5(
     JMXTelemetryConfigModel.apply
   )
-  implicit lazy val jdbcConnectionConfigFormat: RootJsonFormat[JdbcConnectionConfig] = jsonFormat5(JdbcConnectionConfig.apply)
+  implicit lazy val jdbcConnectionConfigFormat: RootJsonFormat[JdbcConnectionConfig] = jsonFormat5(
+    JdbcConnectionConfig.apply
+  )
   implicit lazy val jdbcConfigModelFormat: RootJsonFormat[JdbcConfigModel] = jsonFormat2(JdbcConfigModel.apply)
   implicit lazy val nifiConfigModelFormat: RootJsonFormat[NifiConfigModel] = jsonFormat4(NifiConfigModel.apply)
-  implicit lazy val compilerConfigModelFormat: RootJsonFormat[CompilerConfigModel] = jsonFormat2(CompilerConfigModel.apply)
-
+  implicit lazy val compilerConfigModelFormat: RootJsonFormat[CompilerConfigModel] = jsonFormat2(
+    CompilerConfigModel.apply
+  )
 
   implicit lazy val telemetryTopicConfigModel: RootJsonFormat[TelemetryTopicConfigModel] = jsonFormat5(
     TelemetryTopicConfigModel.apply
@@ -175,65 +180,110 @@ trait JsonSupport
     override def read(json: JsValue): HttpCompression =
       json match {
         case JsString(value) => HttpCompression.fromString(value)
-        case other => throw new RuntimeException(s"Cannot parse http compression format from $other")
+        case other           => throw new RuntimeException(s"Cannot parse http compression format from $other")
       }
   }
-  implicit lazy val httpModelFormat: RootJsonFormat[HttpModel] = jsonFormat9(HttpModel.apply)
-  implicit lazy val genericProductFormat: RootJsonFormat[GenericProduct] = jsonFormat2(GenericProduct.apply)
-  implicit lazy val genericModelFormat: RootJsonFormat[GenericModel] = jsonFormat4(GenericModel.apply)
+  implicit lazy val httpModelFormat: RootJsonFormat[HttpModel]               = jsonFormat9(HttpModel.apply)
+  implicit lazy val genericProductFormat: RootJsonFormat[GenericProduct]     = jsonFormat2(GenericProduct.apply)
+  implicit lazy val genericModelFormat: RootJsonFormat[GenericModel]         = jsonFormat4(GenericModel.apply)
   implicit lazy val genericOptionModelFormat: RootJsonFormat[GenericOptions] = jsonFormat1(GenericOptions.apply)
   implicit lazy val datastoreProductFormat: RootJsonFormat[DatastoreProduct] = DatastoreProductJsonFormat
-  implicit lazy val streamingReaderModelFormat: RootJsonFormat[StreamingReaderModel] = jsonFormat5(
+  implicit lazy val streamingReaderModelFormat: RootJsonFormat[StreamingReaderModel] = jsonFormat6(
     (
-      name: String,
-      datastoreModelName: String,
-      datastoreProduct: DatastoreProduct,
-      rateLimit: Option[Int],
-      options: Map[String, String]
-    ) => StreamingReaderModel(name, datastoreModelName, datastoreProduct, rateLimit, options)
+        name: String,
+        datastoreModelName: String,
+        datastoreProduct: DatastoreProduct,
+        rateLimit: Option[Int],
+        options: Map[String, String],
+        parsingMode: ParsingMode
+    ) =>
+      StreamingReaderModel(
+        name,
+        datastoreModelName,
+        datastoreProduct,
+        rateLimit,
+        options,
+        parsingMode
+      )
   )
-  implicit lazy val readerModelFormat: RootJsonFormat[ReaderModel] = jsonFormat4(
-    (name: String, datastoreModelName: String, datastoreProduct: DatastoreProduct, options: Map[String, String]) =>
-      ReaderModel(name, datastoreModelName, datastoreProduct, options)
+  implicit lazy val readerModelFormat: RootJsonFormat[ReaderModel] = jsonFormat5(
+    (
+        name: String,
+        datastoreModelName: String,
+        datastoreProduct: DatastoreProduct,
+        options: Map[String, String],
+        parsingMode: ParsingMode
+    ) =>
+      ReaderModel(
+        name,
+        datastoreModelName,
+        datastoreProduct,
+        options,
+        parsingMode
+      )
   )
+  implicit lazy val parsingModeFormat: JsonFormat[ParsingMode] = new JsonFormat[ParsingMode] {
+    override def write(obj: ParsingMode): JsValue =
+      JsString(obj.mode)
+
+    override def read(json: JsValue): ParsingMode =
+      json match {
+        case JsString(value) if ParsingMode.fromString(value).nonEmpty => ParsingMode.fromString(value).get
+        case JsString(value) =>
+          throw new SparkException(
+            s"parsingMode $value is not a valid one, allowed values are ${ParsingMode.map.keys.mkString(",")}"
+          )
+        case other => throw new SparkException(s"parsingMode ${json.toString()} is not a string")
+      }
+  }
   implicit lazy val writerModelFormat: RootJsonFormat[WriterModel] = jsonFormat4(
     (name: String, datastoreModelName: String, datastoreProduct: DatastoreProduct, options: Map[String, String]) =>
       WriterModel(name, datastoreModelName, datastoreProduct, options)
   )
 
-  implicit lazy val cdcModelFormat: RootJsonFormat[CdcModel] = jsonFormat4(CdcModel.apply)
-  implicit lazy val cdcOptionModelFormat: RootJsonFormat[CdcOptions] = jsonFormat4(CdcOptions.apply)
-  implicit lazy val rawModelFormat: RootJsonFormat[RawModel] = jsonFormat5(RawModel.apply)
-  implicit lazy val rawOptionModelFormat: RootJsonFormat[RawOptions] = jsonFormat4(RawOptions.apply)
-  implicit lazy val keyValueModelFormat: RootJsonFormat[KeyValueModel] = jsonFormat6(KeyValueModel.apply)
+  implicit lazy val cdcModelFormat: RootJsonFormat[CdcModel]                  = jsonFormat4(CdcModel.apply)
+  implicit lazy val cdcOptionModelFormat: RootJsonFormat[CdcOptions]          = jsonFormat4(CdcOptions.apply)
+  implicit lazy val rawModelFormat: RootJsonFormat[RawModel]                  = jsonFormat5(RawModel.apply)
+  implicit lazy val rawOptionModelFormat: RootJsonFormat[RawOptions]          = jsonFormat4(RawOptions.apply)
+  implicit lazy val keyValueModelFormat: RootJsonFormat[KeyValueModel]        = jsonFormat6(KeyValueModel.apply)
   implicit lazy val keyValueOptionModelFormat: RootJsonFormat[KeyValueOption] = jsonFormat2(KeyValueOption.apply)
 
   implicit lazy val mlModelOnlyInfoFormat: RootJsonFormat[MlModelOnlyInfo] = jsonFormat7(MlModelOnlyInfo.apply)
-  implicit lazy val strategyModelFormat: RootJsonFormat[StrategyModel] = jsonFormat2(StrategyModel.apply)
-  implicit lazy val dashboardModelFormat: RootJsonFormat[DashboardModel] = jsonFormat2(DashboardModel.apply)
-  implicit lazy val restEnrichmentSourceFormat: RootJsonFormat[RestEnrichmentSource] = jsonFormat3(RestEnrichmentSource.apply)
-  implicit lazy val restEnrichmentConfigModel: RootJsonFormat[RestEnrichmentConfigModel] = jsonFormat1(RestEnrichmentConfigModel.apply)
+  implicit lazy val strategyModelFormat: RootJsonFormat[StrategyModel]     = jsonFormat2(StrategyModel.apply)
+  implicit lazy val dashboardModelFormat: RootJsonFormat[DashboardModel]   = jsonFormat2(DashboardModel.apply)
+  implicit lazy val restEnrichmentSourceFormat: RootJsonFormat[RestEnrichmentSource] = jsonFormat3(
+    RestEnrichmentSource.apply
+  )
+  implicit lazy val restEnrichmentConfigModel: RootJsonFormat[RestEnrichmentConfigModel] = jsonFormat1(
+    RestEnrichmentConfigModel.apply
+  )
   implicit lazy val etlStructuredModelFormat: RootJsonFormat[StructuredStreamingETLModel] = jsonFormat9(
     StructuredStreamingETLModel.apply
   )
-  implicit lazy val rTModelFormat: RootJsonFormat[RTModel] = jsonFormat5(RTModel.apply)
-  implicit lazy val pipegraphModelFormat: RootJsonFormat[PipegraphModel] = jsonFormat9(PipegraphModel.apply)
+  implicit lazy val rTModelFormat: RootJsonFormat[RTModel]                   = jsonFormat5(RTModel.apply)
+  implicit lazy val pipegraphModelFormat: RootJsonFormat[PipegraphModel]     = jsonFormat9(PipegraphModel.apply)
   implicit lazy val connectionConfigFormat: RootJsonFormat[ConnectionConfig] = jsonFormat5(ConnectionConfig.apply)
   implicit lazy val zookeeperConnectionFormat: RootJsonFormat[ZookeeperConnectionsConfig] = jsonFormat2(
     ZookeeperConnectionsConfig.apply
   )
   implicit lazy val kafkaEntryConfigModelFormat: RootJsonFormat[KafkaEntryConfig] = jsonFormat2(KafkaEntryConfig.apply)
-  implicit lazy val kafkaConfigModelFormat: RootJsonFormat[KafkaConfigModel] = jsonFormat13(KafkaConfigModel.apply)
-  implicit lazy val sparkDriverConfigFormat: RootJsonFormat[SparkDriverConfig] = jsonFormat7(SparkDriverConfig.apply)
+  implicit lazy val kafkaConfigModelFormat: RootJsonFormat[KafkaConfigModel]      = jsonFormat13(KafkaConfigModel.apply)
+  implicit lazy val sparkDriverConfigFormat: RootJsonFormat[SparkDriverConfig]    = jsonFormat7(SparkDriverConfig.apply)
   implicit lazy val kryoSerializerConfigFormat: RootJsonFormat[KryoSerializerConfig] = jsonFormat3(
     KryoSerializerConfig.apply
   )
   implicit lazy val sparkEntryConfigModelConfigFormat: RootJsonFormat[SparkEntryConfig] = jsonFormat2(
     SparkEntryConfig.apply
   )
-  implicit lazy val nifiStatelessConfigModelFormat: RootJsonFormat[NifiStatelessConfigModel] = jsonFormat4(NifiStatelessConfigModel.apply)
-  implicit lazy val retainedConfigModelFormat: RootJsonFormat[RetainedConfigModel] = jsonFormat5(RetainedConfigModel.apply)
-  implicit lazy val schedulingStrategyConfigModelFormat: RootJsonFormat[SchedulingStrategyConfigModel] = jsonFormat2(SchedulingStrategyConfigModel.apply)
+  implicit lazy val nifiStatelessConfigModelFormat: RootJsonFormat[NifiStatelessConfigModel] = jsonFormat4(
+    NifiStatelessConfigModel.apply
+  )
+  implicit lazy val retainedConfigModelFormat: RootJsonFormat[RetainedConfigModel] = jsonFormat5(
+    RetainedConfigModel.apply
+  )
+  implicit lazy val schedulingStrategyConfigModelFormat: RootJsonFormat[SchedulingStrategyConfigModel] = jsonFormat2(
+    SchedulingStrategyConfigModel.apply
+  )
   implicit lazy val sparkStreamingConfigModelFormat: RootJsonFormat[SparkStreamingConfigModel] = jsonFormat20(
     SparkStreamingConfigModel.apply
   )
@@ -244,8 +294,8 @@ trait JsonSupport
     HBaseEntryConfig.apply
   )
   implicit lazy val hbaseConfigModelConfigFormat: RootJsonFormat[HBaseConfigModel] = jsonFormat4(HBaseConfigModel.apply)
-  implicit lazy val elasticConfigModelFormat: RootJsonFormat[ElasticConfigModel] = jsonFormat2(ElasticConfigModel.apply)
-  implicit lazy val solrConfigModelFormat: RootJsonFormat[SolrConfigModel] = jsonFormat2(SolrConfigModel.apply)
+  implicit lazy val elasticConfigModelFormat: RootJsonFormat[ElasticConfigModel]   = jsonFormat2(ElasticConfigModel.apply)
+  implicit lazy val solrConfigModelFormat: RootJsonFormat[SolrConfigModel]         = jsonFormat2(SolrConfigModel.apply)
   implicit lazy val batchJobExclusionConfig: RootJsonFormat[BatchJobExclusionConfig] = jsonFormat2(
     BatchJobExclusionConfig.apply
   )
@@ -253,11 +303,11 @@ trait JsonSupport
   implicit lazy val batchETLModelFormat: RootJsonFormat[BatchETLModel] = jsonFormat8(BatchETLModel.apply)
   implicit lazy val batchETLGdprModelFormat: RootJsonFormat[BatchGdprETLModel] =
     jsonFormat(BatchGdprETLModel.apply, "name", "dataStores", "strategyConfig", "inputs", "output", "group", "isActive")
-  implicit lazy val batchETLFormat: RootJsonFormat[BatchETL] = createBatchETLFormat
-  implicit lazy val batchJobModelFormat: RootJsonFormat[BatchJobModel] = jsonFormat7(BatchJobModel.apply)
-  implicit lazy val producerModelFormat: RootJsonFormat[ProducerModel] = jsonFormat7(ProducerModel.apply)
+  implicit lazy val batchETLFormat: RootJsonFormat[BatchETL]             = createBatchETLFormat
+  implicit lazy val batchJobModelFormat: RootJsonFormat[BatchJobModel]   = jsonFormat7(BatchJobModel.apply)
+  implicit lazy val producerModelFormat: RootJsonFormat[ProducerModel]   = jsonFormat7(ProducerModel.apply)
   implicit lazy val jobStatusFormat: RootJsonFormat[JobStatus.JobStatus] = new EnumJsonConverter(JobStatus)
-  implicit lazy val typesafeConfigFormat: RootJsonFormat[Config] = new TypesafeConfigJsonConverter
+  implicit lazy val typesafeConfigFormat: RootJsonFormat[Config]         = new TypesafeConfigJsonConverter
   implicit lazy val batchJobInstanceModelFormat: RootJsonFormat[BatchJobInstanceModel] = jsonFormat7(
     BatchJobInstanceModel.apply
   )
@@ -267,10 +317,10 @@ trait JsonSupport
   implicit lazy val pipegraphInstanceModelFormat: RootJsonFormat[PipegraphInstanceModel] = jsonFormat8(
     PipegraphInstanceModel.apply
   )
-  implicit lazy val documentModelFormat: RootJsonFormat[DocumentModel] = jsonFormat3(DocumentModel.apply)
-  implicit lazy val freeCodeModelFormat: RootJsonFormat[FreeCodeModel] = jsonFormat2(FreeCodeModel.apply)
-  implicit lazy val freeCodeFormat: RootJsonFormat[FreeCode] = jsonFormat1(FreeCode.apply)
-  implicit lazy val errorModelFormat: RootJsonFormat[ErrorModel] = jsonFormat6(ErrorModel.apply)
+  implicit lazy val documentModelFormat: RootJsonFormat[DocumentModel]     = jsonFormat3(DocumentModel.apply)
+  implicit lazy val freeCodeModelFormat: RootJsonFormat[FreeCodeModel]     = jsonFormat2(FreeCodeModel.apply)
+  implicit lazy val freeCodeFormat: RootJsonFormat[FreeCode]               = jsonFormat1(FreeCode.apply)
+  implicit lazy val errorModelFormat: RootJsonFormat[ErrorModel]           = jsonFormat6(ErrorModel.apply)
   implicit lazy val completionModelFormat: RootJsonFormat[CompletionModel] = jsonFormat2(CompletionModel.apply)
 
   implicit lazy val websocketModelFormat: RootJsonFormat[WebsocketModel] = jsonFormat5(WebsocketModel.apply)
@@ -301,7 +351,7 @@ trait JsonSupport
   }
 
   implicit lazy val processGroupResponseFormat: RootJsonFormat[ProcessGroupResponse] = jsonFormat2(ProcessGroupResponse)
-  implicit lazy val processGroupModelFormat: RootJsonFormat[ProcessGroupModel] = jsonFormat3(ProcessGroupModel)
+  implicit lazy val processGroupModelFormat: RootJsonFormat[ProcessGroupModel]       = jsonFormat3(ProcessGroupModel)
 
   /*
    Pipegrpaph editor formats
@@ -314,8 +364,8 @@ trait JsonSupport
   implicit lazy val errorDTOFormat: RootJsonFormat[ErrorDTO] = jsonFormat1(ErrorDTO.apply)
 
   // Strategy DTO formats
-  implicit lazy val freeCodeDTOFormat: RootJsonFormat[FreeCodeDTO] = jsonFormat3(FreeCodeDTO)
-  implicit lazy val flowNifiDTOFormat: RootJsonFormat[FlowNifiDTO] = jsonFormat3(FlowNifiDTO)
+  implicit lazy val freeCodeDTOFormat: RootJsonFormat[FreeCodeDTO]           = jsonFormat3(FreeCodeDTO)
+  implicit lazy val flowNifiDTOFormat: RootJsonFormat[FlowNifiDTO]           = jsonFormat3(FlowNifiDTO)
   implicit lazy val strategyClassDTOFormat: RootJsonFormat[StrategyClassDTO] = jsonFormat2(StrategyClassDTO)
 
   implicit lazy val strategyDTOFormat: RootJsonFormat[StrategyDTO] = new RootJsonFormat[StrategyDTO] {
@@ -325,11 +375,11 @@ trait JsonSupport
         .getFields("strategyType")
         .headOption match {
         case Some(JsString(StrategyDTO.freecodeType)) => freeCodeDTOFormat.read(json)
-        case Some(JsString(StrategyDTO.nifiType)) => flowNifiDTOFormat.read(json)
+        case Some(JsString(StrategyDTO.nifiType))     => flowNifiDTOFormat.read(json)
         case Some(JsString(StrategyDTO.codebaseType)) => strategyClassDTOFormat.read(json)
-        case Some(_) => deserializationError(s"$json is not a StrategyDTO subclass")
-        case None => deserializationError(s"$json it's missing a strategyType field")
-        case _ => deserializationError(s"$json It's not a valid StrategyDTO")
+        case Some(_)                                  => deserializationError(s"$json is not a StrategyDTO subclass")
+        case None                                     => deserializationError(s"$json it's missing a strategyType field")
+        case _                                        => deserializationError(s"$json It's not a valid StrategyDTO")
       }
 
     override def write(obj: StrategyDTO): JsValue = obj match {
@@ -357,7 +407,7 @@ trait JsonSupport
   implicit lazy val topicModelDTOFormat: RootJsonFormat[TopicModelDTO] = jsonFormat1(TopicModelDTO)
   implicit lazy val indexModelDTOFormat: RootJsonFormat[IndexModelDTO] = jsonFormat1(IndexModelDTO)
   implicit lazy val kvModelDTOFormat: RootJsonFormat[KeyValueModelDTO] = jsonFormat1(KeyValueModelDTO)
-  implicit lazy val rawModelDTOFormat: RootJsonFormat[RawModelDTO] = jsonFormat2(RawModelDTO)
+  implicit lazy val rawModelDTOFormat: RootJsonFormat[RawModelDTO]     = jsonFormat2(RawModelDTO)
 
   implicit lazy val datastoreDTOFormat: RootJsonFormat[DatastoreModelDTO] = new RootJsonFormat[DatastoreModelDTO] {
     override def read(json: JsValue): DatastoreModelDTO =
@@ -365,13 +415,13 @@ trait JsonSupport
         .asJsObject("Datastore DTO should be an JSON Object")
         .getFields("modelType")
         .headOption match {
-        case Some(JsString(DatastoreModelDTO.topicType)) => topicModelDTOFormat.read(json)
-        case Some(JsString(DatastoreModelDTO.indexType)) => indexModelDTOFormat.read(json)
+        case Some(JsString(DatastoreModelDTO.topicType))    => topicModelDTOFormat.read(json)
+        case Some(JsString(DatastoreModelDTO.indexType))    => indexModelDTOFormat.read(json)
         case Some(JsString(DatastoreModelDTO.keyValueType)) => kvModelDTOFormat.read(json)
-        case Some(JsString(DatastoreModelDTO.rawDataType)) => rawModelDTOFormat.read(json)
-        case Some(_) => deserializationError(s"$json is not a DatastoreDTO subclass")
-        case None => deserializationError(s"$json it's missing a modelType field")
-        case _ => deserializationError(s"$json It's not a valid DatastoreDTO")
+        case Some(JsString(DatastoreModelDTO.rawDataType))  => rawModelDTOFormat.read(json)
+        case Some(_)                                        => deserializationError(s"$json is not a DatastoreDTO subclass")
+        case None                                           => deserializationError(s"$json it's missing a modelType field")
+        case _                                              => deserializationError(s"$json It's not a valid DatastoreDTO")
       }
 
     override def write(obj: DatastoreModelDTO): JsValue = obj match {

--- a/plugin-kafka-spark/src/main/scala/it/agilelab/bigdata/wasp/consumers/spark/plugins/kafka/KafkaSparkStreamingReaders.scala
+++ b/plugin-kafka-spark/src/main/scala/it/agilelab/bigdata/wasp/consumers/spark/plugins/kafka/KafkaSparkStreamingReaders.scala
@@ -9,11 +9,14 @@ import it.agilelab.bigdata.wasp.core.kafka.CheckOrCreateTopic
 import it.agilelab.bigdata.wasp.core.logging.Logging
 import it.agilelab.bigdata.wasp.core.utils._
 import it.agilelab.bigdata.wasp.models._
+import it.agilelab.bigdata.wasp.models.configuration.{Handle, Ignore, ParsingMode, Strict}
 import it.agilelab.bigdata.wasp.repository.core.bl.{ConfigBL, TopicBL}
 import it.agilelab.bigdata.wasp.spark.sql.kafka011.KafkaSparkSQLSchemas
 import it.agilelab.darwin.manager.AvroSchemaManagerFactory
 import org.apache.avro.Schema
-import org.apache.spark.sql.catalyst.expressions.CaseWhen
+import org.apache.spark.SparkException
+import org.apache.spark.sql.catalyst.expressions.{CaseWhen, Hex}
+import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{DataType, StringType}
 import org.apache.spark.sql.{Column, DataFrame, SparkSession}
@@ -21,7 +24,9 @@ import org.apache.spark.sql.{Column, DataFrame, SparkSession}
 import scala.collection.mutable
 
 object KafkaSparkStructuredStreamingReader extends SparkStructuredStreamingReader with Logging {
-  private val KAFKA_METADATA_COL = "kafkaMetadata"
+  private val KAFKA_METADATA_COL       = "kafkaMetadata"
+  private val RAW_VALUE_ATTRIBUTE_NAME = "raw"
+  private val DATA_TYPE_ATTRIBUTE_NAME = "dataType"
 
   /**
     * Creates a streaming DataFrame from a Kafka streaming source.
@@ -31,7 +36,7 @@ object KafkaSparkStructuredStreamingReader extends SparkStructuredStreamingReade
     * named after the value fields depending on the topic datatype.
     * If the input topics do not share the same schema the returned Dataframe will contain a column named
     * "kafkaMetadata" with message metadata and each topic content on a column named after the topic name,
-    * previously escaped calling the function [[MultiTopicModel.topicNameToColumnName()]].
+    * previously escaped calling the function [[MultiTopicModel.topicModelNames()]].
     * This means that if 5 topic models with different schema are read, the output dataframe will contain 6 columns,
     * and of these 6 columns only the kafkaMetadata and the topic related to that message one, will have a value
     * different from null, like the following:
@@ -46,17 +51,70 @@ object KafkaSparkStructuredStreamingReader extends SparkStructuredStreamingReade
     * }}}
     *
     * The "kafkaMetadata" column contains the following:
-    * - key: bytes
-    * - headers: array of {headerKey: string, headerValue: bytes}
-    * - topic: string
-    * - partition: int
-    * - offset: long
-    * - timestamp: timestamp
-    * - timestampType: int
-    *
+    * <ul>
+    * <li>key: bytes</li>
+    * <li>headers: array of {headerKey: string, headerValue: bytes}</li>
+    * <li>topic: string</li>
+    * <li>partition: int</li>
+    * <li>offset: long</li>
+    * <li>timestamp: timestamp</li>
+    * <li>timestampType: int</li>
+    *</ul>
+    * <br>
     * The behaviour for message contents column(s) is the following:
-    * - the "avro" and "json" topic data types will output the columns specified by their schemas
-    * - the "plaintext" and "bytes" topic data types output a "value" column with the contents as string or bytes respectively
+    * <ul>
+    * <li>the "avro" and "json" topic data types will output the columns specified by their schemas</li>
+    * <li>the "plaintext" and "bytes" topic data types output a "value" column with the contents as string or bytes respectively</li>
+    * </ul>
+    * <br>
+    * There is also the possibility to manage a Parsing mode for Avro/json deserialization, this param can be:
+    * <ul>
+    * <li>Strict: job will crash when a record can't be parsed</li>
+    * <li>Ignore: records that are impossible to parse will be filtered out</li>
+    * <li>Handle: produce two columns instead of exploding the schema of parsed record, one containing raw bytes array,
+    *     and the other containing the parsed value, if parsing it's ok, or null if parsing error has happened</li>
+    * </ul>
+    * <u>In Strict and Ignore mode result dataframe will have the same schema described early</u><br>
+    * In Handle mode, for single topic when topic type is Avro/Json the structure will have:
+    * <ul>
+    *  <li>kafkaMetadata -> same as other mode</li>
+    *  <li>raw           -> raw byte array, it will be null if parsing has worked fine, else it will contain raw byte array</li>
+    *  <li>value         -> struct column that contains parsed record or null if parsing had problems</li>
+    *  </ul>
+    *  Here is example
+    *  {{{
+    * +--------------------+--------------------+-------------------------+
+    * |       kafkaMetadata|                 raw|                    value|
+    * +--------------------+--------------------+-------------------------+
+    * |[45, [], test_jso...|          [45, 47..]|                     null|
+    * |[12, [], testchec...|                null|      [12, 77, [field1_..|
+    * +--------------------+--------------------+-------------------------+
+    * }}}
+    * <u>Handle mode is meant to divide the good data from bad data through a simple where(col("raw").isNull),
+    * than good data can be exploded through select(col("value.*"))</u>
+    * <p><b>N.B in Single reading mode Parsing Mode on binary/plaintext topic type will be ignored</b></p>
+    *
+    * <br>Handle parsing mode in multi mode scenario will be managed as standard multi mode plus the column "raw", which
+    * has the same usage as single mode.
+    * an example result is like:
+    * {{{
+    * +--------------------------------+----+------------+--------------+-----------------+-------------+
+    *|                   kafkaMetadata| raw|  topic_json|  topic_binary|      topic_plain|    topic_avro|
+    *+--------------------------------+----+------------+--------------+-----------------+--------------+
+    *|[1, [], topic_json,.............|null| [1, valore]|          null|             null|          null|
+    *|[1, [], topic_binary,...........|null|        null|   binary_test|             null|          null|
+    *|[1, [], topic_plain,............|null|        null|          null|   plaintext_test|          null|
+    *|[1, [], topic_avro,.............|[05]|        null|          null|             null|          null|
+    *|[1, [], topic_avro,.............|null|        null|          null|             null|   [1, valore]|
+    *+--------------------------------+----+------------+--------------+-----------------+--------------+
+    * }}}
+    * <u>In case of error raw column will be populated else is null,
+    * to access parsed value is possible to select column "[topic_name]" this field will be null if parsing didn't work</u>
+    * <b>
+    *  <br><br>N.B. when a parsing error occurs, every topic_name column will have null as value, you can know one which one
+    *  parsing error has occurred by looking at kafkaMetadata.topic field
+    *  <br><br>N.B. for plaintext and binary type, since is possible to have topic_name.value = null, raw column will be null
+    * as well (since is populated only for parsing errors which cannot happen on these types). </b>
     */
   override def createStructuredStream(etl: StructuredStreamingETLModel, streamingReaderModel: StreamingReaderModel)(
       implicit ss: SparkSession
@@ -112,8 +170,9 @@ object KafkaSparkStructuredStreamingReader extends SparkStructuredStreamingReade
         .format("kafka")
         .options(options)
         .load()
+        .withColumn(RAW_VALUE_ATTRIBUTE_NAME, col(KafkaSparkSQLSchemas.VALUE_ATTRIBUTE_NAME))
 
-      parseDF(topics, df)
+      parseDF(topics, df, streamingReaderModel.parsingMode)
 
     } else {
       val msg = s"Unable to check/create one or more topic; topics: $topics"
@@ -129,7 +188,8 @@ object KafkaSparkStructuredStreamingReader extends SparkStructuredStreamingReade
         .map(_.name)
         .filter(cName =>
           cName != KafkaSparkSQLSchemas.VALUE_ATTRIBUTE_NAME &&
-            cName != KafkaSparkSQLSchemas.KEY_ATTRIBUTE_NAME
+            cName != KafkaSparkSQLSchemas.KEY_ATTRIBUTE_NAME &&
+            cName != RAW_VALUE_ATTRIBUTE_NAME
         )
         .toList
 
@@ -147,9 +207,9 @@ object KafkaSparkStructuredStreamingReader extends SparkStructuredStreamingReade
     * different topic name which will contain the parsed data from that topic. This means that if there are 10 different
     * topics to fetch with 10 different schemas the dataframe will have 11 columns and every row will contain 9 null
     * values, one column with the parsed message and one with the kafka metadata. The column names will reflect the
-    * topic names but will be sanitized by the function [[MultiTopicModel.topicNameToColumnName()]].
+    * topic names but will be sanitized by the function [[MultiTopicModel.topicModelNames]].
     */
-  private def parseDF(topics: Seq[TopicModel], df: DataFrame) = {
+  private def parseDF(topics: Seq[TopicModel], df: DataFrame, parsingMode: ParsingMode) = {
     MultiTopicModel.areTopicsHealthy(topics) match {
       case Left(a) => throw new IllegalArgumentException(a)
       case Right(_) =>
@@ -160,27 +220,34 @@ object KafkaSparkStructuredStreamingReader extends SparkStructuredStreamingReade
                 throw new IllegalArgumentException(error)
               case Right(_) =>
                 logger.debug(s"Suppressing error: '$a' and trying with multipleSchema strategy")
-                selectForMultipleSchema(topics, df)
+                selectForMultipleSchema(topics, df, parsingMode)
             }
           case Right(_) =>
-            selectForOneSchema(topics.head, df)
+            selectForOneSchema(topics.head, df, parsingMode)
         }
     }
   }
 
-  private[wasp] def selectForOneSchema(prototypeTopic: TopicModel, df: DataFrame) = {
-    val ret: DataFrame = prototypeTopic.topicDataType match {
+  private[wasp] def selectForOneSchema(prototypeTopic: TopicModel, df: DataFrame, parsingMode: ParsingMode) = {
+    val topicType = prototypeTopic.topicDataType
+    if (parsingMode == Handle && !Seq(TopicDataTypes.JSON, TopicDataTypes.AVRO).contains(topicType)) {
+      logger.warn(
+        s"Handle parsing mode is not supported for $topicType topic type, it will be managed as in " +
+          s"Strict mode (so no raw column will be produced). To remove this warning please set Strict as parsing mode " +
+          s"of your topic. Look at KafkaSparkStructuredStreamingReader#createStructuredStream java doc for more details."
+      )
+    }
+    val ret: DataFrame = topicType match {
       case TopicDataTypes.AVRO =>
         // parse avro bytes into a column, lift the contents up one level and push metadata into nested column
-        df.withColumn("value_parsed", parseAvroValue(prototypeTopic))
-          .drop(KafkaSparkSQLSchemas.VALUE_ATTRIBUTE_NAME)
-          .select(selectMetadata(parseKey(prototypeTopic)), expr("value_parsed.*"))
+        val parsedDf = df.withColumn(KafkaSparkSQLSchemas.VALUE_ATTRIBUTE_NAME, parseAvroValue(prototypeTopic))
+        checkParsingMode(parsedDf, parsingMode, TopicDataTypes.AVRO, parseKey(prototypeTopic))
       case TopicDataTypes.JSON =>
-        df.withColumn(
-            KafkaSparkSQLSchemas.VALUE_ATTRIBUTE_NAME,
-            from_json(parseString, getDataType(prototypeTopic.getJsonSchema))
-          )
-          .select(selectMetadata(), expr("value.*"))
+        val parsedDf = df.withColumn(
+          KafkaSparkSQLSchemas.VALUE_ATTRIBUTE_NAME,
+          from_json(parseString, getDataType(prototypeTopic.getJsonSchema))
+        )
+        checkParsingMode(parsedDf, parsingMode, TopicDataTypes.JSON)
       case TopicDataTypes.PLAINTEXT =>
         df.withColumn("value_string", parseString)
           .select(selectMetadata(), expr("value_string AS value"))
@@ -194,19 +261,88 @@ object KafkaSparkStructuredStreamingReader extends SparkStructuredStreamingReade
     ret
   }
 
-  private[wasp] def selectForMultipleSchema(topics: Seq[TopicModel], df: DataFrame) = {
+  /**
+    * Checks if parsing has happened correctly and behave differently basing on input parsing mode,
+    * to check if a record has been parsed it checks that value column is not null :
+    * <ul>
+    * <li>Strict, launches an exception when unable to parse </li>
+    * <li>Ignore, filters out record that are not been parsed</li>
+    * <li>Handle, return raw column as null when parsing is good, else it's populated with original byte array</li>
+    * </ul>
+    *
+    * @param df
+    * @param parsingMode
+    * @param topicDataType
+    * @param metadataKey
+    * @return metadata + exploded parsed fields for Strict and Ignore, metadata+ raw + value column when Handle mode,
+    *         parsed values are in value column and can be exploded through value.*
+    *  @throws SparkException when unable to parse a record in Strict mode
+    */
+  private[wasp] def checkParsingMode(
+      df: DataFrame,
+      parsingMode: ParsingMode,
+      topicDataType: String,
+      metadataKey: Column = col(KafkaSparkSQLSchemas.KEY_ATTRIBUTE_NAME)
+  ): DataFrame = {
+    parsingMode match {
+      case Strict =>
+        val computedValue = "computedValue"
+        df.withColumn(
+            computedValue,
+            when(
+              col(KafkaSparkSQLSchemas.VALUE_ATTRIBUTE_NAME).isNull,
+              strictExceptionLauncherUdf(col(RAW_VALUE_ATTRIBUTE_NAME), lit(topicDataType))
+            ).otherwise(col(KafkaSparkSQLSchemas.VALUE_ATTRIBUTE_NAME))
+          )
+          .select(selectMetadata(metadataKey), col(s"$computedValue.*"))
+      case Ignore =>
+        df.select(selectMetadata(metadataKey), col(s"${KafkaSparkSQLSchemas.VALUE_ATTRIBUTE_NAME}.*"))
+          .where(col(KafkaSparkSQLSchemas.VALUE_ATTRIBUTE_NAME).isNotNull)
+      case Handle =>
+        df.select(
+          selectMetadata(metadataKey),
+          when(
+            col(KafkaSparkSQLSchemas.VALUE_ATTRIBUTE_NAME).isNull,
+            col(RAW_VALUE_ATTRIBUTE_NAME)
+          ).otherwise(null)
+            .as(RAW_VALUE_ATTRIBUTE_NAME),
+          col(KafkaSparkSQLSchemas.VALUE_ATTRIBUTE_NAME)
+        )
+    }
+  }
+
+  /**
+    * function that prints the content of the serialized value which is not deserializable,
+    * it's useful to know which record caused the error
+    *
+    * @throws SparkException exception containing the record which has caused the parsing error
+    */
+  private[wasp] def strictExceptionLauncherUdf: UserDefinedFunction =
+    udf((raw: Array[Byte], topicDataType: String) => {
+      topicDataType match {
+        case TopicDataTypes.JSON =>
+          throw new SparkException(
+            s"Unable to parse raw value [${StringToByteArrayUtil.byteArrayToString(raw)}] to $topicDataType"
+          )
+        case TopicDataTypes.AVRO =>
+          throw new SparkException(s"Unable to parse raw value [${Hex.hex(raw)}] to $topicDataType")
+      }
+    })
+
+  private[wasp] def selectForMultipleSchema(topics: Seq[TopicModel], df: DataFrame, parsingMode: ParsingMode) = {
     val valueColumns = topics
       .foldLeft(List.empty[Column]) { (cols, t) =>
-        t.topicDataType match {
+        val dataType = t.topicDataType
+        dataType match {
           case TopicDataTypes.AVRO =>
-            parseIfMyTopicOrNull(t.name, parseAvroValue(t)) :: cols
+            parseIfMyTopicOrNull(t.name, parseAvroValue(t), dataType) :: cols
           case TopicDataTypes.JSON =>
-            parseIfMyTopicOrNull(t.name, parseJson(t)) :: cols
+            parseIfMyTopicOrNull(t.name, parseJson(t), dataType) :: cols
           case TopicDataTypes.PLAINTEXT =>
-            parseIfMyTopicOrNull(t.name, parseString) :: cols
+            parseIfMyTopicOrNull(t.name, parseString, dataType) :: cols
           case TopicDataTypes.BINARY =>
             // push metadata into nested column and keep value as is
-            parseIfMyTopicOrNull(t.name, parseBinary) :: cols
+            parseIfMyTopicOrNull(t.name, parseBinary, dataType) :: cols
           case _ =>
             throw new UnsupportedOperationException(s"""Unsupported topic data type "${t.topicDataType}"""")
         }
@@ -223,22 +359,82 @@ object KafkaSparkStructuredStreamingReader extends SparkStructuredStreamingReade
       case None    => selectMetadata()
     }
 
-    val ret = df.select(metadataExpr :: valueColumns: _*)
-    logger.debug(s"DataFrame schema: ${ret.schema.treeString}")
-    ret
+    val ret = df.select(metadataExpr :: col(RAW_VALUE_ATTRIBUTE_NAME) :: valueColumns: _*)
+    logger.debug(s"DataFrame schema before parsing mode check: ${ret.schema.treeString}")
+    val retChecked = checkParsingModeMultipleTopics(ret, parsingMode)
+    logger.debug(s"DataFrame schema after parsing mode check: ${ret.schema.treeString}")
+    retChecked
+  }
+
+  /**
+    * Checks if parsing has happened correctly and behave differently basing on input parsing mode,
+    * to check if a record has been parsed it checks that topicName.value column is not null :
+    * <ul>
+    *   <li>Strict, launches an exception when unable to parse </li>
+    *   <li>Ignore, filters out record that are not been parsed</li>
+    *   <li>Handle, return raw column as null when parsing is good, else populated with original byte array</li>
+    * </ul>
+    * @param df
+    * @param parsingMode
+    * @return df parsed according to input parsing mode
+    * @throws SparkException
+    */
+  private[wasp] def checkParsingModeMultipleTopics(df: DataFrame, parsingMode: ParsingMode) = {
+    val parsedCols = df.columns.diff(Seq(KAFKA_METADATA_COL, RAW_VALUE_ATTRIBUTE_NAME))
+
+    def parsedValueCol(colName: String) = col(s"$colName.${KafkaSparkSQLSchemas.VALUE_ATTRIBUTE_NAME}")
+
+    def parsedDataTypeCol(colName: String) = col(s"$colName.$DATA_TYPE_ATTRIBUTE_NAME")
+
+    //check for extra safety, binary and plaintext type should not be null
+    def dataTypeToCheckCondition(colName: String) =
+      col(colName).isNull || lower(parsedDataTypeCol(colName)).isin(TopicDataTypes.JSON, TopicDataTypes.AVRO)
+
+    val goodCaseSelect = parsedCols.map(c => when(col(c).isNotNull, parsedValueCol(c)).otherwise(null).as(c))
+    val parsingErrorFilteredCondition = parsedCols
+      .map(c =>
+        col(c).isNull || !dataTypeToCheckCondition(c) || (dataTypeToCheckCondition(c) && parsedValueCol(c).isNotNull)
+      )
+      .reduce(_ and _)
+
+    parsingMode match {
+      case Strict =>
+        parsedCols
+          .foldLeft(df) { (df, c) =>
+            df.withColumn(
+              "workingColumn",
+              when(
+                dataTypeToCheckCondition(c) && col(c).isNotNull && parsedValueCol(c).isNull,
+                strictExceptionLauncherUdf(col(RAW_VALUE_ATTRIBUTE_NAME), parsedDataTypeCol(c))
+              ).otherwise(null)
+            )
+          }
+          .select(col(KAFKA_METADATA_COL) +: goodCaseSelect: _*)
+      case Ignore =>
+        df.where(parsingErrorFilteredCondition).select(col(KAFKA_METADATA_COL) +: goodCaseSelect: _*)
+
+      case Handle =>
+        val rawCol =
+          when(!parsingErrorFilteredCondition, col(RAW_VALUE_ATTRIBUTE_NAME))
+            .otherwise(null)
+            .as(RAW_VALUE_ATTRIBUTE_NAME)
+        df.select(Seq(col(KAFKA_METADATA_COL), rawCol) ++ goodCaseSelect: _*)
+    }
+
   }
 
   private def parseBinary = {
-    col(KafkaSparkSQLSchemas.VALUE_ATTRIBUTE_NAME)
+    col(RAW_VALUE_ATTRIBUTE_NAME)
   }
 
   private def parseString = {
-    col(KafkaSparkSQLSchemas.VALUE_ATTRIBUTE_NAME).cast(StringType)
+    col(RAW_VALUE_ATTRIBUTE_NAME).cast(StringType)
   }
 
   private def parseJson(t: TopicModel) = {
     from_json(parseString, getDataType(t.getJsonSchema))
   }
+
   // expression that parses the key of the topic.
   // if the key does not have a schema is left binary as-is.
   // if the key has a schema is parsed as avro using it
@@ -283,6 +479,7 @@ object KafkaSparkStructuredStreamingReader extends SparkStructuredStreamingReade
         col(KafkaSparkSQLSchemas.KEY_ATTRIBUTE_NAME)
     }
   }
+
   private def parseAvroValue(t: TopicModel): Column = {
     logger.debug(s"AVRO value schema: ${new Schema.Parser().parse(t.getJsonSchema).toString(true)}")
     val darwinConf = if (t.useAvroSchemaManager) {
@@ -312,7 +509,7 @@ object KafkaSparkStructuredStreamingReader extends SparkStructuredStreamingReade
     }
 
     val avroToRowConversion = AvroDeserializerExpression(
-      col(KafkaSparkSQLSchemas.VALUE_ATTRIBUTE_NAME).expr,
+      col(RAW_VALUE_ATTRIBUTE_NAME).expr,
       schemaToUse.get,
       darwinConf,
       avoidReevaluation = true
@@ -341,11 +538,22 @@ object KafkaSparkStructuredStreamingReader extends SparkStructuredStreamingReade
     AvroSchemaConverters.toSqlType(schemaAvro).dataType
   }
 
-  private def parseIfMyTopicOrNull(topicName: String, parseCol: Column): Column = {
+  /**
+    * @param topicName topic name which value should match topic column value
+    * @param parseCol  column which contains parsed value
+    * @param dataType  input schema for data in the topic
+    * @return null if the current row doesn't match requested topic, else a struct of parsed value as 'value'
+    *         and topic encoding data type
+    */
+  private def parseIfMyTopicOrNull(topicName: String, parseCol: Column, dataType: String): Column = {
     def when(condition: Column, value: Column): Column = new Column(CaseWhen(Seq((condition.expr, value.expr))))
-    when(col(KafkaSparkSQLSchemas.TOPIC_ATTRIBUTE_NAME).equalTo(topicName), parseCol)
-      .otherwise(null)
+
+    when(
+      col(KafkaSparkSQLSchemas.TOPIC_ATTRIBUTE_NAME).equalTo(topicName),
+      struct(parseCol.as(KafkaSparkSQLSchemas.VALUE_ATTRIBUTE_NAME), lit(dataType).as(DATA_TYPE_ATTRIBUTE_NAME))
+    ).otherwise(null)
       .as(topicNameToColumnName(topicName))
+
   }
 
 }

--- a/plugin-kafka-spark/src/test/scala/it/agilelab/bigdata/wasp/consumers/spark/plugins/kafka/KafkaSparkStructuredStreamingReaderSpec.scala
+++ b/plugin-kafka-spark/src/test/scala/it/agilelab/bigdata/wasp/consumers/spark/plugins/kafka/KafkaSparkStructuredStreamingReaderSpec.scala
@@ -3,200 +3,661 @@ package it.agilelab.bigdata.wasp.consumers.spark.plugins.kafka
 import com.sksamuel.avro4s.{AvroOutputStream, AvroSchema}
 import it.agilelab.bigdata.wasp.consumers.spark.plugins.kafka.TopicModelUtils.topicNameToColumnName
 import it.agilelab.bigdata.wasp.consumers.spark.utils.SparkSuite
-import it.agilelab.bigdata.wasp.models.{TopicCompression, TopicModel}
+import it.agilelab.bigdata.wasp.models.configuration._
+import it.agilelab.bigdata.wasp.models.{TopicCompression, TopicDataTypes, TopicModel}
+import org.apache.spark.SparkException
+import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.{BinaryType, StringType, StructField, StructType}
 import org.bson.BsonDocument
-import org.scalatest.FlatSpec
+import org.scalatest.WordSpec
 
 import java.io.ByteArrayOutputStream
 import java.nio.charset.StandardCharsets
 import java.sql.Timestamp
+import scala.util.{Failure, Success, Try}
 
-class KafkaSparkStructuredStreamingReaderSpec extends FlatSpec with SparkSuite {
-
-  it should "parse only data in correct column when in multi-mode" in {
-    import spark.implicits._
-    val schema = BsonDocument.parse(AvroSchema[MockRecord].toString(true))
-    val topic1 = TopicModel(
-      "topic1.topic",
-      0L,
-      0,
-      0,
-      "plaintext",
-      None,
-      None,
-      Some(Nil),
-      false,
-      schema,
-      TopicCompression.Snappy
-    )
-    val topic2 = topic1.copy(
-      name = "topic2",
-      topicDataType = "json",
-      topicCompression = TopicCompression.Snappy
-    )
-    val topic3 = topic2.copy(
-      name = "topic3",
-      topicDataType = "binary",
-      topicCompression = TopicCompression.Snappy
-    )
-    val topic4 = topic2.copy(
-      name = "topic4",
-      topicDataType = "avro",
-      topicCompression = TopicCompression.Snappy
-    )
-    val topic5 = topic4.copy(
-      name = "topic5",
-      topicDataType = "avro",
-      schema = BsonDocument.parse(AvroSchema[MockRecord2].toString(true)),
-      topicCompression = TopicCompression.Snappy
-    )
-    val df = spark
-      .createDataset(
-        Seq(
-          KafkaFakeRecord(
-            key = "1".getBytes(StandardCharsets.UTF_8),
-            value = """{"key":"1", "value":"valore"}""".getBytes(StandardCharsets.UTF_8),
-            headers = Array.empty,
-            topic = topic1.name,
-            partition = 1,
-            offset = 0L,
-            timestamp = new Timestamp(0L),
-            timestampType = 0
-          ),
-          KafkaFakeRecord(
-            key = "1".getBytes(StandardCharsets.UTF_8),
-            value = """{"key":"1", "value":"valore"}""".getBytes(StandardCharsets.UTF_8),
-            headers = Array.empty,
-            topic = topic2.name,
-            partition = 1,
-            offset = 0L,
-            timestamp = new Timestamp(0L),
-            timestampType = 0
-          ),
-          KafkaFakeRecord(
-            key = "1".getBytes(StandardCharsets.UTF_8),
-            value = """asfdasdgasffa""".getBytes(StandardCharsets.UTF_8),
-            headers = Array.empty,
-            topic = topic3.name,
-            partition = 1,
-            offset = 0L,
-            timestamp = new Timestamp(0L),
-            timestampType = 0
-          ),
-          KafkaFakeRecord(
-            key = "1".getBytes(StandardCharsets.UTF_8),
-            value = {
-              val bos = new ByteArrayOutputStream()
-              val aos = AvroOutputStream.binary[MockRecord](bos)
-              aos.write(MockRecord("k", "v"))
-              aos.flush()
-              aos.close()
-              bos.toByteArray
-            },
-            headers = Array.empty,
-            topic = topic4.name,
-            partition = 1,
-            offset = 0L,
-            timestamp = new Timestamp(0L),
-            timestampType = 0
-          ),
-          KafkaFakeRecord(
-            key = "1".getBytes(StandardCharsets.UTF_8),
-            value = {
-              val bos = new ByteArrayOutputStream()
-              val aos = AvroOutputStream.binary[MockRecord2](bos)
-              aos.write(MockRecord2("z"))
-              aos.flush()
-              aos.close()
-              bos.toByteArray
-            },
-            headers = Array.empty,
-            topic = topic5.name,
-            partition = 1,
-            offset = 0L,
-            timestamp = new Timestamp(0L),
-            timestampType = 0
+class KafkaSparkStructuredStreamingReaderSpec extends WordSpec with SparkSuite {
+  import spark.implicits._
+  "single schema mode" should {
+    "parse only data in correct column" in {
+      val schema = BsonDocument.parse(AvroSchema[MockRecord].toString(true))
+      val topic1 = TopicModel(
+        "topic1.topic",
+        0L,
+        0,
+        0,
+        "json",
+        None,
+        None,
+        Some(Nil),
+        false,
+        schema,
+        TopicCompression.Snappy
+      )
+      val topic2 = topic1.copy(name = "topic2")
+      val topic3 = topic1.copy(name = "topic3")
+      val topic4 = topic1.copy(name = "topic4")
+      val df = spark
+        .createDataset(
+          Seq(
+            KafkaFakeRecord(
+              key = "1".getBytes(StandardCharsets.UTF_8),
+              raw = """{"key":"1", "raw":"valore"}""".getBytes(StandardCharsets.UTF_8),
+              headers = Array.empty,
+              topic = topic1.name,
+              partition = 1,
+              offset = 0L,
+              timestamp = new Timestamp(0L),
+              timestampType = 0
+            ),
+            KafkaFakeRecord(
+              key = "1".getBytes(StandardCharsets.UTF_8),
+              raw = """{"key":"1", "raw":"valore"}""".getBytes(StandardCharsets.UTF_8),
+              headers = Array.empty,
+              topic = topic2.name,
+              partition = 1,
+              offset = 0L,
+              timestamp = new Timestamp(0L),
+              timestampType = 0
+            )
           )
         )
+        .toDF()
+
+      assert(TopicModelUtils.areTopicsEqualForReading(Seq(topic1, topic2, topic3, topic4)).isRight)
+
+      val outDF = KafkaSparkStructuredStreamingReader
+        .selectForOneSchema(topic1, df, Strict)
+      assert(outDF.where(col("value").isNull.or(col("key").isNull)).count() === 0)
+    }
+
+    "parse correctly in STRICT mode a dataset to json" in {
+      val topic = topicTest("json")
+      val allRightData = mockedSingleJsonData match {
+        case start :+ last =>
+          start :+ last.copy(raw = """{"key":"1", "value":"value3"}""".getBytes(StandardCharsets.UTF_8))
+      }
+      val df = spark.createDataFrame(allRightData)
+      val outDf = KafkaSparkStructuredStreamingReader
+        .selectForOneSchema(topic, df, Strict)
+      assert(outDf.where(col("value").isNull).count() === 0)
+    }
+
+    "throw an exception parsing in STRICT mode a dataset with errors to json" in {
+      val topic = topicTest("json")
+      val df    = spark.createDataFrame(mockedSingleJsonData)
+
+      val outDf = KafkaSparkStructuredStreamingReader
+        .selectForOneSchema(topic, df, Strict)
+
+      strictExceptionCheck(outDf, "json")
+    }
+
+    "parse correctly in IGNORE mode a dataset with errors to json" in {
+      val topic = topicTest("json")
+      val df    = spark.createDataFrame(mockedSingleJsonData)
+
+      val outDf = KafkaSparkStructuredStreamingReader.selectForOneSchema(topic, df, Ignore).cache
+      assert(outDf.where(col("value").isNull).count() === 0)
+      assert(outDf.where(col("value").isNotNull).count() === 2)
+      checkResultSchema(outDf, false)
+    }
+
+    "parse correctly in HANDLE mode a dataset with errors to json" in {
+      val topic = topicTest("json")
+      val df    = spark.createDataFrame(mockedSingleJsonData)
+
+      val outDf = KafkaSparkStructuredStreamingReader.selectForOneSchema(topic, df, Handle).cache
+      assert(outDf.where(col("raw").isNull).count() === 2)
+      assert(outDf.where(col("raw").isNotNull).count() === 1)
+      assert(outDf.where(col("value").isNull).count() === 1)
+      assert(outDf.where(col("value").isNotNull).count() === 2)
+      checkResultSchema(outDf, true)
+    }
+
+    "parse correctly in STRICT mode a dataset to avro" in {
+      val topic = topicTest("avro")
+      val correctedData = mockedSingleAvroData match {
+        case start :+ last =>
+          start :+ last.copy(raw = {
+            val bos = new ByteArrayOutputStream()
+            val aos = AvroOutputStream.binary[MockRecord](bos)
+            aos.write(MockRecord("k3", "value3"))
+            aos.flush()
+            aos.close()
+            bos.toByteArray
+          })
+      }
+      val df    = spark.createDataFrame(correctedData)
+      val outDf = KafkaSparkStructuredStreamingReader.selectForOneSchema(topic, df, Strict).cache
+      assert(outDf.where(col("value").isNull).count() === 0)
+      checkResultSchema(outDf, false)
+    }
+
+    "throw an exception parsing in STRICT mode a dataset with errors to avro" in {
+      val topic = topicTest("avro")
+      val df    = spark.createDataFrame(mockedSingleAvroData)
+
+      val outDf = KafkaSparkStructuredStreamingReader.selectForOneSchema(topic, df, Strict)
+
+      strictExceptionCheck(outDf, "avro")
+    }
+
+    "parse correctly in IGNORE mode a dataset with errors to avro" in {
+      val topic = topicTest("avro")
+      val df    = spark.createDataFrame(mockedSingleAvroData)
+      val outDf = KafkaSparkStructuredStreamingReader.selectForOneSchema(topic, df, Ignore).cache
+      assert(outDf.where(col("value").isNull).count() === 0)
+      assert(outDf.where(col("value").isNotNull).count() === 2)
+      checkResultSchema(outDf, isHandleMode = false)
+    }
+
+    "parse correctly in HANDLE mode a dataset with errors to avro" in {
+      val topic = topicTest("avro")
+      val df    = spark.createDataFrame(mockedSingleAvroData)
+
+      val outDf = KafkaSparkStructuredStreamingReader.selectForOneSchema(topic, df, Handle).cache
+      assert(outDf.where(col("raw").isNull).count() === 2)
+      assert(outDf.where(col("raw").isNotNull).count() === 1)
+      assert(outDf.where(col("value").isNull).count() === 1)
+      assert(outDf.where(col("value").isNotNull).count() === 2)
+      checkResultSchema(outDf, isHandleMode = true)
+    }
+
+  }
+  "multiple schemas mode" should {
+    "parse only data in correct column" in {
+      val schema = BsonDocument.parse(AvroSchema[MockRecord].toString(true))
+      val topic1 = TopicModel(
+        "topic1.topic",
+        0L,
+        0,
+        0,
+        "plaintext",
+        None,
+        None,
+        Some(Nil),
+        false,
+        schema,
+        TopicCompression.Snappy
       )
-      .toDF()
+      val topic2 = topic1.copy(
+        name = "topic2",
+        topicDataType = "json",
+        topicCompression = TopicCompression.Snappy
+      )
+      val topic3 = topic2.copy(
+        name = "topic3",
+        topicDataType = "binary",
+        topicCompression = TopicCompression.Snappy
+      )
+      val topic4 = topic2.copy(
+        name = "topic4",
+        topicDataType = "avro",
+        topicCompression = TopicCompression.Snappy
+      )
+      val topic5 = topic4.copy(
+        name = "topic5",
+        topicDataType = "avro",
+        schema = BsonDocument.parse(AvroSchema[MockRecord2].toString(true)),
+        topicCompression = TopicCompression.Snappy
+      )
+      val df = spark
+        .createDataset(
+          Seq(
+            KafkaFakeRecord(
+              key = "1".getBytes(StandardCharsets.UTF_8),
+              raw = """{"key":"1", "raw":"valore"}""".getBytes(StandardCharsets.UTF_8),
+              headers = Array.empty,
+              topic = topic1.name,
+              partition = 1,
+              offset = 0L,
+              timestamp = new Timestamp(0L),
+              timestampType = 0
+            ),
+            KafkaFakeRecord(
+              key = "1".getBytes(StandardCharsets.UTF_8),
+              raw = """{"key":"1", "raw":"valore"}""".getBytes(StandardCharsets.UTF_8),
+              headers = Array.empty,
+              topic = topic2.name,
+              partition = 1,
+              offset = 0L,
+              timestamp = new Timestamp(0L),
+              timestampType = 0
+            ),
+            KafkaFakeRecord(
+              key = "1".getBytes(StandardCharsets.UTF_8),
+              raw = """asfdasdgasffa""".getBytes(StandardCharsets.UTF_8),
+              headers = Array.empty,
+              topic = topic3.name,
+              partition = 1,
+              offset = 0L,
+              timestamp = new Timestamp(0L),
+              timestampType = 0
+            ),
+            KafkaFakeRecord(
+              key = "1".getBytes(StandardCharsets.UTF_8),
+              raw = {
+                val bos = new ByteArrayOutputStream()
+                val aos = AvroOutputStream.binary[MockRecord](bos)
+                aos.write(MockRecord("k", "v"))
+                aos.flush()
+                aos.close()
+                bos.toByteArray
+              },
+              headers = Array.empty,
+              topic = topic4.name,
+              partition = 1,
+              offset = 0L,
+              timestamp = new Timestamp(0L),
+              timestampType = 0
+            ),
+            KafkaFakeRecord(
+              key = "1".getBytes(StandardCharsets.UTF_8),
+              raw = {
+                val bos = new ByteArrayOutputStream()
+                val aos = AvroOutputStream.binary[MockRecord2](bos)
+                aos.write(MockRecord2("z"))
+                aos.flush()
+                aos.close()
+                bos.toByteArray
+              },
+              headers = Array.empty,
+              topic = topic5.name,
+              partition = 1,
+              offset = 0L,
+              timestamp = new Timestamp(0L),
+              timestampType = 0
+            )
+          )
+        )
+        .toDF()
 
-    val outDF = KafkaSparkStructuredStreamingReader
-      .selectForMultipleSchema(Seq(topic1, topic2, topic3, topic4, topic5), df)
+      val outDF = KafkaSparkStructuredStreamingReader
+        .selectForMultipleSchema(Seq(topic1, topic2, topic3, topic4, topic5), df, Strict)
 
-    assert(outDF.where(col(topicNameToColumnName(topic1.name)).isNotNull).count() === 1)
-    assert(outDF.where(col(topic2.name).isNotNull).count() === 1)
-    assert(outDF.where(col(topic3.name).isNotNull).count() === 1)
-    assert(outDF.where(col(topic4.name).isNotNull).count() === 1)
-    assert(outDF.where(col(topic5.name).isNotNull).count() === 1)
-    assert(outDF.where(col(topicNameToColumnName(topic1.name)).isNull).count() === 4)
-    assert(outDF.where(col(topic2.name).isNull).count() === 4)
-    assert(outDF.where(col(topic3.name).isNull).count() === 4)
-    assert(outDF.where(col(topic4.name).isNull).count() === 4)
-    assert(outDF.where(col(topic5.name).isNull).count() === 4)
+      assert(outDF.where(col(topicNameToColumnName(topic1.name)).isNotNull).count() === 1)
+      assert(outDF.where(col(topic2.name).isNotNull).count() === 1)
+      assert(outDF.where(col(topic3.name).isNotNull).count() === 1)
+      assert(outDF.where(col(topic4.name).isNotNull).count() === 1)
+      assert(outDF.where(col(topic5.name).isNotNull).count() === 1)
+      assert(outDF.where(col(topicNameToColumnName(topic1.name)).isNull).count() === 4)
+      assert(outDF.where(col(topic2.name).isNull).count() === 4)
+      assert(outDF.where(col(topic3.name).isNull).count() === 4)
+      assert(outDF.where(col(topic4.name).isNull).count() === 4)
+      assert(outDF.where(col(topic5.name).isNull).count() === 4)
+    }
+
+    "parse Strict and Ignore mode correctly" in {
+      val df = spark.createDataset(mockedMultiTopicData).toDF()
+
+      val outDF = KafkaSparkStructuredStreamingReader
+        .selectForMultipleSchema(multiTopicSeq, df, Strict)
+        .cache
+
+      multiTopicSeq.map(t => col(t.name)).foreach { c =>
+        assert(outDF.where(c.isNotNull).count() === 1)
+        assert(outDF.where(c.isNull).count() === 3)
+      }
+
+      val ignoreOut = KafkaSparkStructuredStreamingReader.selectForMultipleSchema(multiTopicSeq, df, Strict).cache
+      assert(ignoreOut.exceptAll(outDF).isEmpty)
+      assert(outDF.exceptAll(ignoreOut).isEmpty)
+    }
+
+    "parse Handle mode correctly" in {
+      val df = spark.createDataset(mockedMultiTopicData).toDF()
+
+      val outDF = KafkaSparkStructuredStreamingReader
+        .selectForMultipleSchema(multiTopicSeq, df, Handle)
+        .cache
+      val rawCol = col("raw")
+
+      multiTopicSeq.foreach { t =>
+        val name = t.name
+        assert(outDF.where(rawCol.isNull && col(name).isNotNull).count() === 1)
+      }
+    }
+
+    "break when parsing error on json and Strict mode" in {
+      val editedSample = mockedMultiTopicData match {
+        case d1 :: tail =>
+          val editD1 = d1.copy(raw = """{"key":"1",,malformed,,, "v1":"valore"}""".getBytes(StandardCharsets.UTF_8))
+          editD1 +: tail
+      }
+      val df = spark.createDataset(editedSample).toDF()
+
+      val outDF = KafkaSparkStructuredStreamingReader
+        .selectForMultipleSchema(multiTopicSeq, df, Strict)
+      strictExceptionCheck(outDF, "json")
+    }
+
+    "filter when parsing error on json and Ignore mode" in {
+      val editedSample = mockedMultiTopicData match {
+        case d1 :: tail =>
+          val editD1 = d1.copy(raw = """{"key":"1",,malformed,,, "v1":"valore"}""".getBytes(StandardCharsets.UTF_8))
+          editD1 +: tail
+      }
+      val df = spark.createDataset(editedSample).toDF()
+
+      val outDF = KafkaSparkStructuredStreamingReader.selectForMultipleSchema(multiTopicSeq, df, Ignore)
+      multiTopicSeq.tail.map(t => col(t.name)).foreach { c =>
+        assert(outDF.where(c.isNotNull).count() === 1)
+        assert(outDF.where(c.isNull).count() === 2)
+      }
+      val cjson = col(multiTopicSeq.head.name)
+      assert(outDF.where(cjson.isNotNull).count() === 0)
+      assert(outDF.where(cjson.isNull).count() === 3)
+    }
+
+    "return raw when parsing error on json and Handle mode" in {
+      val editedSample = mockedMultiTopicData match {
+        case d1 :: tail =>
+          val editD1 = d1.copy(raw = """{"key":"1",,malformed,,, "v1":"valore"}""".getBytes(StandardCharsets.UTF_8))
+          editD1 +: tail
+      }
+      val df               = spark.createDataset(editedSample).toDF()
+      val rawCol           = col("raw")
+      val topicJsonColName = s"${multiTopicSeq.head.name}"
+      val outDF            = KafkaSparkStructuredStreamingReader.selectForMultipleSchema(multiTopicSeq, df, Handle).cache()
+
+      multiTopicSeq.tail.foreach { t =>
+        val name = t.name
+        assert(outDF.where(rawCol.isNull && col(name).isNotNull).count() === 1)
+      }
+      assert(outDF.where(rawCol.isNotNull && col(topicJsonColName).isNull).count() === 1)
+    }
+
+    "break when parsing error on avro and Strict mode" in {
+      val editedSample = mockedMultiTopicData match {
+        case start :+ d4 =>
+          val editD4 = d4.copy(raw = Array(5))
+          start :+ editD4
+      }
+      val df = spark.createDataset(editedSample).toDF()
+
+      val outDF = KafkaSparkStructuredStreamingReader
+        .selectForMultipleSchema(multiTopicSeq, df, Strict)
+      strictExceptionCheck(outDF, "avro")
+    }
+
+    "filter when parsing error on avro and Ignore mode" in {
+      val editedSample = mockedMultiTopicData match {
+        case start :+ d4 =>
+          val editD4 = d4.copy(raw = Array(5))
+          start :+ editD4
+      }
+      val df = spark.createDataset(editedSample).toDF()
+
+      val outDF = KafkaSparkStructuredStreamingReader.selectForMultipleSchema(multiTopicSeq, df, Ignore).cache()
+
+      multiTopicSeq.dropRight(1).map(t => col(t.name)).foreach { c =>
+        assert(outDF.where(c.isNotNull).count() === 1)
+        assert(outDF.where(c.isNull).count() === 2)
+      }
+      val cavro = col(multiTopicSeq.last.name)
+      assert(outDF.where(cavro.isNotNull).count() === 0)
+      assert(outDF.where(cavro.isNull).count() === 3)
+    }
+
+    "return raw when parsing error on avro and Handle mode" in {
+      val editedSample = mockedMultiTopicData match {
+        case start :+ d4 =>
+          val editD4 = d4.copy(raw = Array(5))
+          start :+ editD4
+      }
+      val df = spark.createDataset(editedSample).toDF()
+
+      val rawCol           = col("raw")
+      val topicAvroColName = s"${multiTopicSeq.last.name}"
+      val outDF            = KafkaSparkStructuredStreamingReader.selectForMultipleSchema(multiTopicSeq, df, Handle).cache()
+
+      multiTopicSeq.dropRight(1).foreach { t =>
+        val name = t.name
+        assert(outDF.where(rawCol.isNull && col(name).isNotNull).count() === 1)
+      }
+      assert(outDF.where(rawCol.isNotNull && col(topicAvroColName).isNull).count() === 1)
+    }
+
+    "go ahead for null plaintext and binary messages with Strict and Ignore mode" in {
+      val Seq(t1, t2, t3, t4) = multiTopicSeq
+      val editedSample = mockedMultiTopicData match {
+        case d1 :: d2 :: d3 :: d4 :: _ =>
+          val editD2 = d2.copy(raw = null)
+          val editD3 = d3.copy(raw = null)
+          Seq(d1, editD2, editD3, d4)
+      }
+      val df = spark.createDataset(editedSample).toDF()
+
+      val outDF = KafkaSparkStructuredStreamingReader
+        .selectForMultipleSchema(multiTopicSeq, df, Strict)
+        .cache
+      assert(outDF.where(col(t1.name).isNotNull).count() === 1)
+      assert(outDF.where(col(t4.name).isNotNull).count() === 1)
+      assert(outDF.where(col(t1.name).isNull).count() === 3)
+      assert(outDF.where(col(t4.name).isNull).count() === 3)
+      assert(outDF.where(col(t2.name).isNull).count() === 4)
+      assert(outDF.where(col(t3.name).isNull).count() === 4)
+      val ignoreOut = KafkaSparkStructuredStreamingReader.selectForMultipleSchema(multiTopicSeq, df, Strict).cache
+      assert(ignoreOut.exceptAll(outDF).isEmpty)
+      assert(outDF.exceptAll(ignoreOut).isEmpty)
+    }
+
+    "null raw for null plaintext and binary messages with Handle mode" in {
+      val Seq(t1, t2, t3, t4) = multiTopicSeq
+
+      val editedSample = mockedMultiTopicData match {
+        case d1 :: d2 :: d3 :: d4 :: _ =>
+          val editD2 = d2.copy(raw = null)
+          val editD3 = d3.copy(raw = null)
+          Seq(d1, editD2, editD3, d4)
+      }
+      val df = spark.createDataset(editedSample).toDF()
+
+      val outDF = KafkaSparkStructuredStreamingReader
+        .selectForMultipleSchema(multiTopicSeq, df, Handle)
+        .cache
+      val rawCol = col("raw")
+      Seq(t1, t4).foreach { t =>
+        val name = t.name
+        assert(outDF.where(rawCol.isNull && col(name).isNotNull).count() === 1)
+      }
+      Seq(t2, t3).foreach { t =>
+        val name = t.name
+        assert(outDF.where(rawCol.isNull && col(name).isNull && col("kafkametadata.topic") === name).count() === 1)
+      }
+    }
   }
 
-  it should "parse only data in correct column when in single mode" in {
-    import spark.implicits._
-    val schema = BsonDocument.parse(AvroSchema[MockRecord].toString(true))
-    val topic1 = TopicModel(
-      "topic1.topic",
-      0L,
-      0,
-      0,
-      "json",
-      None,
-      None,
-      Some(Nil),
-      false,
-      schema,
-      TopicCompression.Snappy
+  def strictExceptionCheck(df: DataFrame, string2contain: String) = {
+    Try(df.collect) match {
+      case Success(_)                 => fail("a spark exception should be thrown, not a Success")
+      case Failure(e: SparkException) => assert(e.getCause.toString.contains(string2contain))
+      case Failure(e)                 => fail(s"a spark exception should be thrown, not $e ")
+    }
+  }
+  def checkResultSchema(df: DataFrame, isHandleMode: Boolean): Unit = {
+    val parsedValue = StructType(
+      Array(StructField("key", StringType, nullable = false), StructField("v1", StringType, nullable = false))
     )
-    val topic2 = topic1.copy(name = "topic2")
-    val topic3 = topic1.copy(name = "topic3")
-    val topic4 = topic1.copy(name = "topic4")
-    val df = spark
-      .createDataset(
-        Seq(
-          KafkaFakeRecord(
-            key = "1".getBytes(StandardCharsets.UTF_8),
-            value = """{"key":"1", "value":"valore"}""".getBytes(StandardCharsets.UTF_8),
-            headers = Array.empty,
-            topic = topic1.name,
-            partition = 1,
-            offset = 0L,
-            timestamp = new Timestamp(0L),
-            timestampType = 0
-          ),
-          KafkaFakeRecord(
-            key = "1".getBytes(StandardCharsets.UTF_8),
-            value = """{"key":"1", "value":"valore"}""".getBytes(StandardCharsets.UTF_8),
-            headers = Array.empty,
-            topic = topic2.name,
-            partition = 1,
-            offset = 0L,
-            timestamp = new Timestamp(0L),
-            timestampType = 0
-          )
-        )
+    val handleSchema = StructType(
+      Array(
+        StructField("raw", BinaryType),
+        StructField("value", parsedValue)
       )
-      .toDF()
+    )
+    val toCheck = df.drop("kafkaMetadata").schema.toString().replaceAll(",true", ",false")
+    if (isHandleMode) {
+      assert(handleSchema.toString().replaceAll(",true", ",false") == toCheck)
+    } else {
+      assert(parsedValue.toString().replaceAll(",true", ",false") == toCheck)
+    }
+  }
+  def topicTest(_type: String, name: String = "topic-test"): TopicModel = TopicModel(
+    name,
+    0L,
+    0,
+    0,
+    _type,
+    None,
+    None,
+    Some(Nil),
+    useAvroSchemaManager = false,
+    BsonDocument.parse(AvroSchema[MockRecord].toString(true)),
+    TopicCompression.Snappy
+  )
 
-    assert(TopicModelUtils.areTopicsEqualForReading(Seq(topic1, topic2, topic3, topic4)).isRight)
+  val multiTopicSeq = Seq(
+    topicTest(TopicDataTypes.JSON, "topic_json"),
+    topicTest(TopicDataTypes.BINARY, "topic_binary"),
+    topicTest(TopicDataTypes.PLAINTEXT, "topic_plain"),
+    topicTest(TopicDataTypes.AVRO, "topic_avro")
+  )
 
-    val outDF = KafkaSparkStructuredStreamingReader
-      .selectForOneSchema(topic1, df)
-
-    assert(outDF.where(col("value").isNull.or(col("key").isNull)).count() === 0)
+  val mockedMultiTopicData = {
+    val Seq(t1, t2, t3, t4) = multiTopicSeq
+    Seq(
+      KafkaFakeRecord(
+        key = "1".getBytes(StandardCharsets.UTF_8),
+        raw = """{"key":"1", "v1":"valore"}""".getBytes(StandardCharsets.UTF_8),
+        headers = Array.empty,
+        topic = t1.name,
+        partition = 1,
+        offset = 0L,
+        timestamp = new Timestamp(0L),
+        timestampType = 0
+      ),
+      KafkaFakeRecord(
+        key = "1".getBytes(StandardCharsets.UTF_8),
+        raw = """binary_test""".getBytes(StandardCharsets.UTF_8),
+        headers = Array.empty,
+        topic = t2.name,
+        partition = 1,
+        offset = 0L,
+        timestamp = new Timestamp(0L),
+        timestampType = 0
+      ),
+      KafkaFakeRecord(
+        key = "1".getBytes(StandardCharsets.UTF_8),
+        raw = """plaintext_test""".getBytes(StandardCharsets.UTF_8),
+        headers = Array.empty,
+        topic = t3.name,
+        partition = 1,
+        offset = 0L,
+        timestamp = new Timestamp(0L),
+        timestampType = 0
+      ),
+      KafkaFakeRecord(
+        key = "1".getBytes(StandardCharsets.UTF_8),
+        raw = {
+          val bos = new ByteArrayOutputStream()
+          val aos = AvroOutputStream.binary[MockRecord](bos)
+          aos.write(MockRecord("k", "v"))
+          aos.flush()
+          aos.close()
+          bos.toByteArray
+        },
+        headers = Array.empty,
+        topic = t4.name,
+        partition = 1,
+        offset = 0L,
+        timestamp = new Timestamp(0L),
+        timestampType = 0
+      )
+    )
+  }
+  val mockedSingleJsonData = {
+    val topic = topicTest("json")
+    Seq(
+      KafkaFakeRecord(
+        key = "1".getBytes(StandardCharsets.UTF_8),
+        raw = """{"key":"1", "v1":"value"}""".getBytes(StandardCharsets.UTF_8),
+        headers = Array.empty,
+        topic = topic.name,
+        partition = 1,
+        offset = 0L,
+        timestamp = new Timestamp(0L),
+        timestampType = 0
+      ),
+      KafkaFakeRecord(
+        key = "1".getBytes(StandardCharsets.UTF_8),
+        raw = """{"key":"2", "v1":"value2"}""".getBytes(StandardCharsets.UTF_8),
+        headers = Array.empty,
+        topic = topic.name,
+        partition = 1,
+        offset = 0L,
+        timestamp = new Timestamp(0L),
+        timestampType = 0
+      ),
+      KafkaFakeRecord(
+        key = "1".getBytes(StandardCharsets.UTF_8),
+        raw = """{"key":"3",,, "v1":"value3"}""".getBytes(StandardCharsets.UTF_8),
+        headers = Array.empty,
+        topic = topic.name,
+        partition = 1,
+        offset = 0L,
+        timestamp = new Timestamp(0L),
+        timestampType = 0
+      )
+    )
+  }
+  val mockedSingleAvroData = {
+    val topic = topicTest("avro")
+    Seq(
+      KafkaFakeRecord(
+        key = "1".getBytes(StandardCharsets.UTF_8),
+        raw = {
+          val bos = new ByteArrayOutputStream()
+          val aos = AvroOutputStream.binary[MockRecord](bos)
+          aos.write(MockRecord("k", "value"))
+          aos.flush()
+          aos.close()
+          bos.toByteArray
+        },
+        headers = Array.empty,
+        topic = topic.name,
+        partition = 1,
+        offset = 0L,
+        timestamp = new Timestamp(0L),
+        timestampType = 0
+      ),
+      KafkaFakeRecord(
+        key = "1".getBytes(StandardCharsets.UTF_8),
+        raw = {
+          val bos = new ByteArrayOutputStream()
+          val aos = AvroOutputStream.binary[MockRecord](bos)
+          aos.write(MockRecord("k2", "value2"))
+          aos.flush()
+          aos.close()
+          bos.toByteArray
+        },
+        headers = Array.empty,
+        topic = topic.name,
+        partition = 1,
+        offset = 0L,
+        timestamp = new Timestamp(0L),
+        timestampType = 0
+      ),
+      KafkaFakeRecord(
+        key = "1".getBytes(StandardCharsets.UTF_8),
+        raw = Array(5),
+        headers = Array.empty,
+        topic = topic.name,
+        partition = 1,
+        offset = 0L,
+        timestamp = new Timestamp(0L),
+        timestampType = 0
+      )
+    )
   }
 }
-case class MockRecord(key: String, value: String)
-case class MockRecord2(key: String)
+case class MockRecord(key: String, v1: String)
+case class MockRecord2(raw: String)
 
 case class KafkaFakeRecord(
     key: Array[Byte],
-    value: Array[Byte],
+    raw: Array[Byte],
     headers: Array[(String, Array[Byte])],
     topic: String,
     partition: Int,


### PR DESCRIPTION
# New features and improvements

- Add ParsingMode params to reader component, default to Strict to avoid breaking compatibility with previous implementations
- Edited KafkaSparkStreamingReader to behave according to requested parsing mode, to fulfill that when parsing goes in error a null will be returned and a new function will manage the execution of the right behaviour. ParsingMode functions are: 

    - Single mode -> KafkaSparkStructuredStreamingReader.checkParsingMode
    - Multi mode  -> KafkaSparkStructuredStreamingReader.checkParsingModeMultipleTopics

   Available parsing modes are: 
   - Strict -> raise an exception when a parsing error occurs 
   - Ignore -> filter out records that cannot be parsed 
   - Handle -> return a dataframe with "raw" column with null value if parsing is fine and "value" column with parsed schema, else "raw" column will be populated with original byte array and "value" column will be null

# Breaking changes

None, for every already existing implementation since default ParsingMode is "Strict" which will behave as always, no breaking change even when using ParsingMode = Ignore, but if a downstream application would leverage on Handle ParsingMode, the schema of returned dataFrame will be different and so the implementation may need to be adapted.

# Migration

None.

# Bug fixes

None.

# How this feature was tested

Existing unit tests, new unit tests, Integration test on a downstream implementation

# Related issue

Closes github #13